### PR TITLE
feat: 新增麥克風選擇功能 + UI 修復 (Mic Device Selector)

### DIFF
--- a/audio/recorder.py
+++ b/audio/recorder.py
@@ -17,10 +17,12 @@ class AudioRecorder:
         samplerate: int = 16000,
         channels: int = 1,
         level_callback: Optional[Callable[[float], None]] = None,
+        device: Optional[int] = None,
     ):
         self.samplerate = samplerate
         self.channels = channels
         self.level_callback = level_callback
+        self.device = device  # None = 系統預設麥克風
         self._recording = False
         self._frames: list[np.ndarray] = []
         self._lock = threading.Lock()
@@ -43,6 +45,7 @@ class AudioRecorder:
             samplerate=self.samplerate,
             channels=self.channels,
             dtype="int16",
+            device=self.device,
         )
         self._stream.start()
         
@@ -71,7 +74,7 @@ class AudioRecorder:
                 # 計算音量 RMS (0.0 ~ 1.0) 回傳給 UI
                 if self.level_callback:
                     rms = float(np.sqrt(np.mean(indata.astype(np.float32) ** 2))) / 32768.0
-                    self.level_callback(min(rms * 10, 1.0))
+                    self.level_callback(min(rms * 50, 1.0))
 
             except Exception as e:
                 # 當串流被外界中止或關閉，將引發例外中斷讀取

--- a/config.py
+++ b/config.py
@@ -42,14 +42,17 @@ DEFAULT_CONFIG = {
     # 其他
     "auto_paste": True,
     "magic_trigger": "嘿 VoiceType",
+    # 麥克風
+    "mic_device": None,  # None = 系統預設麥克風
 }
 # 🗝️ 本地設定白名單 (不進行雲端同步的項目)
 LOCAL_KEYS = {
-    "hotkey_ptt", "hotkey_toggle", "hotkey_llm", "hotkey", 
+    "hotkey_ptt", "hotkey_toggle", "hotkey_llm", "hotkey",
     "trigger_mode", "show_floating_button", "completion_sound",
-    "debug_mode", "is_demo", "output_prefix", 
+    "debug_mode", "is_demo", "output_prefix",
     "separate_keystrike_log", "showcase_mode",
-    "stt_engine", "whisper_model"
+    "stt_engine", "whisper_model",
+    "mic_device",
 }
 
 from paths import GLOBAL_CONFIG_PATH, LOCAL_CONFIG_PATH, APP_DATA_DIR

--- a/main.py
+++ b/main.py
@@ -99,7 +99,8 @@ class VoiceTypeApp(QObject):
         self.recorder = AudioRecorder(
             samplerate=16000,
             channels=1,
-            level_callback=self.indicator.set_level
+            level_callback=self.indicator.set_level,
+            device=self.config.get("mic_device"),
         )
         
         self.injector = TextInjector()
@@ -754,6 +755,9 @@ class VoiceTypeApp(QObject):
                         config=self.config
                     )
                     self.hotkey_listener.start()
+            # Refresh mic device if changed
+            self.recorder.device = self.config.get("mic_device")
+
             # Refresh tray menu if needed
             if self.menu_bar:
                 self.menu_bar.config = self.config

--- a/ui/settings_window.py
+++ b/ui/settings_window.py
@@ -1220,14 +1220,17 @@ class SettingsWindow(QMainWindow):
         return page
 
     def _create_general_page(self):
-        page = QWidget()
-        layout = QVBoxLayout(page)
-        
+        page = QScrollArea()
+        page.setWidgetResizable(True)
+        container = QWidget()
+        layout = QVBoxLayout(container)
+
         layout.addWidget(self._page_section_header("⌨️ 設定錄音按鍵"))
         
         hotkey_grid = QFrame()
         grid_layout = QVBoxLayout(hotkey_grid)
-        
+        grid_layout.setSpacing(14)
+
         row_ptt = QHBoxLayout()
         self.btn_ptt = HotkeyRecorderButton(self.config.get("hotkey_ptt", "alt_r"))
         self.btn_ptt.setFixedHeight(32)
@@ -1291,7 +1294,31 @@ class SettingsWindow(QMainWindow):
         grid_layout.addLayout(row_toggle)
         
         layout.addWidget(hotkey_grid)
-        
+
+        layout.addWidget(self._page_section_header("🎤 麥克風選擇"))
+        mic_row = QHBoxLayout()
+        lbl_mic = QLabel("輸入裝置")
+        lbl_mic.setFixedWidth(120)
+        self.mic_device_combo = QComboBox()
+        self.mic_device_combo.setFixedHeight(32)
+        self.mic_device_combo.setFixedWidth(280)
+        self._last_mic_device_names = []
+        self._populate_mic_devices()
+        btn_refresh_mic = QPushButton("🔄")
+        btn_refresh_mic.setFixedWidth(32)
+        btn_refresh_mic.setFixedHeight(32)
+        btn_refresh_mic.setToolTip("重新偵測麥克風裝置")
+        btn_refresh_mic.setStyleSheet("background: transparent; border: none; font-size: 16px; padding: 0px;")
+        btn_refresh_mic.clicked.connect(self._populate_mic_devices)
+        mic_row.addWidget(lbl_mic)
+        mic_row.addWidget(self.mic_device_combo)
+        mic_row.addWidget(btn_refresh_mic)
+        mic_row.addStretch(1)
+        layout.addLayout(mic_row)
+        self._mic_poll_timer = QTimer(self)
+        self._mic_poll_timer.timeout.connect(self._check_mic_devices_changed)
+        self._mic_poll_timer.start(2000)
+
         layout.addWidget(self._page_section_header("⚙️ 偏好設定"))
         self.auto_paste = QCheckBox("結果自動貼上 (Paste automatically)")
         self.auto_paste.setChecked(self.config.get("auto_paste", True))
@@ -1328,32 +1355,43 @@ class SettingsWindow(QMainWindow):
         layout.addWidget(self._page_section_header("🛠️ 診斷與修復"))
         
         diag_grid = QGridLayout()
-        diag_grid.setContentsMargins(0, 5, 0, 5)
-        diag_grid.setSpacing(10)
+        diag_grid.setContentsMargins(0, 10, 0, 10)
+        diag_grid.setVerticalSpacing(16)
+        diag_grid.setHorizontalSpacing(12)
 
-        self.btn_mic_test = QPushButton("🎤 麥克風測試與診斷 (Mic Test)")
+        diag_btn_css = "font-size: 12px; padding: 10px 10px;"
+        self.btn_mic_test = QPushButton("🎤 麥克風測試 (Mic Test)")
         self.btn_mic_test.setObjectName("secondary")
+        self.btn_mic_test.setStyleSheet(diag_btn_css)
+        self.btn_mic_test.setMinimumHeight(44)
         self.btn_mic_test.clicked.connect(self._run_mic_test)
         diag_grid.addWidget(self.btn_mic_test, 0, 0)
-        
-        self.btn_run_self_check = QPushButton("🔍 系統自我檢測 (Self-Check)")
+
+        self.btn_run_self_check = QPushButton("🔍 系統檢測 (Self-Check)")
         self.btn_run_self_check.setObjectName("secondary")
+        self.btn_run_self_check.setStyleSheet(diag_btn_css)
+        self.btn_run_self_check.setMinimumHeight(44)
         self.btn_run_self_check.clicked.connect(self._run_self_check)
         diag_grid.addWidget(self.btn_run_self_check, 0, 1)
 
-        self.btn_view_logs = QPushButton("📄 檢視詳細日誌 (View Detail Logs)")
+        self.btn_view_logs = QPushButton("📄 詳細日誌 (Detail Logs)")
         self.btn_view_logs.setObjectName("secondary")
+        self.btn_view_logs.setStyleSheet(diag_btn_css)
+        self.btn_view_logs.setMinimumHeight(44)
         self.btn_view_logs.clicked.connect(self._view_debug_log)
         diag_grid.addWidget(self.btn_view_logs, 1, 0)
 
-        self.btn_view_keystrike = QPushButton("📄 檢視熱鍵紀錄 (View Keys Logs)")
+        self.btn_view_keystrike = QPushButton("📄 熱鍵紀錄 (Keys Logs)")
         self.btn_view_keystrike.setObjectName("secondary")
+        self.btn_view_keystrike.setStyleSheet(diag_btn_css)
+        self.btn_view_keystrike.setMinimumHeight(44)
         self.btn_view_keystrike.clicked.connect(self._view_keystrike_log)
         diag_grid.addWidget(self.btn_view_keystrike, 1, 1)
 
         layout.addLayout(diag_grid)
         
         layout.addStretch()
+        page.setWidget(container)
         return page
     # ── 同步邏輯 (Sync Logic) ────────────────────────────────────
     def _set_sync_directory(self):
@@ -1745,6 +1783,7 @@ class SettingsWindow(QMainWindow):
         self.config["separate_keystrike_log"] = self.separate_keystrike_log.isChecked()
         self.config["show_floating_button"] = self.show_floating_button.isChecked()
         self.config["showcase_mode"] = self.showcase_mode.isChecked()
+        self.config["mic_device"] = self.mic_device_combo.currentData()
 
         try:
             SOUL_BASE_PATH.write_text(self.soul_prompt.toPlainText().strip(), encoding="utf-8")
@@ -1798,6 +1837,41 @@ class SettingsWindow(QMainWindow):
     def run(self):
         self.show()
 
+    def _get_current_mic_names(self):
+        try:
+            import sounddevice as sd
+            devices = sd.query_devices()
+            return [dev['name'] for dev in devices if dev['max_input_channels'] > 0]
+        except Exception:
+            return []
+
+    def _check_mic_devices_changed(self):
+        current = self._get_current_mic_names()
+        if current != self._last_mic_device_names:
+            self._populate_mic_devices()
+
+    def _populate_mic_devices(self):
+        prev_selection = self.mic_device_combo.currentData()
+        self.mic_device_combo.clear()
+        self.mic_device_combo.addItem("系統預設 (System Default)", None)
+        try:
+            import sounddevice as sd
+            devices = sd.query_devices()
+            names = []
+            for i, dev in enumerate(devices):
+                if dev['max_input_channels'] > 0:
+                    names.append(dev['name'])
+                    self.mic_device_combo.addItem(f"{dev['name']}  (#{i})", i)
+            self._last_mic_device_names = names
+        except Exception as e:
+            log.error(f"[mic] Failed to enumerate devices: {e}")
+            self._last_mic_device_names = []
+        restore = prev_selection if prev_selection is not None else self.config.get("mic_device")
+        if restore is not None:
+            idx = self.mic_device_combo.findData(restore)
+            if idx >= 0:
+                self.mic_device_combo.setCurrentIndex(idx)
+
     def _run_mic_test(self):
         from PyQt6.QtWidgets import QMessageBox, QProgressDialog
         import sounddevice as sd
@@ -1826,7 +1900,8 @@ class SettingsWindow(QMainWindow):
         duration = 3.0
         
         try:
-            recording = sd.rec(int(duration * fs), samplerate=fs, channels=1, dtype='float32')
+            mic_dev = self.mic_device_combo.currentData()
+            recording = sd.rec(int(duration * fs), samplerate=fs, channels=1, dtype='float32', device=mic_dev)
             
             for i in range(3):
                 progress.setValue(i)


### PR DESCRIPTION
## Summary
- 設定頁面新增「🎤 麥克風選擇」下拉選單，使用者可指定錄音裝置（外接麥克風、USB 音訊介面等）
- 每 2 秒自動偵測裝置插拔變化，即時更新下拉選單
- AudioRecorder 新增 `device` 參數，透過 `sounddevice` 指定錄音裝置
- 麥克風測試診斷也會使用選定的裝置
- 設定儲存後即時生效，不需重啟 App
- 提高波紋圖形增益（x10 → x50），改善外接麥克風的視覺回饋
- `mic_device` 加入 `LOCAL_KEYS`，不進行雲端同步

## UI 修復（原始碼既有問題）
- General 頁面改用 `QScrollArea` 包裝，解決內容過多時快捷鍵區域被壓縮重疊
- 快捷鍵三行加入 `grid_layout.setSpacing(14)` 增加行間距
- 診斷按鈕：縮短文字避免裁切、加大最小高度 (44px)、增加垂直間距 (16px)

## Changed Files
| 檔案 | 改動 |
|------|------|
| `config.py` | `DEFAULT_CONFIG` 新增 `mic_device: None`，`LOCAL_KEYS` 新增 `mic_device` |
| `audio/recorder.py` | `__init__` 新增 `device` 參數，`sd.InputStream` 傳入 `device`，增益倍率調高 |
| `main.py` | `AudioRecorder()` 傳入 `device`，`_on_config_saved` 同步更新 `recorder.device` |
| `ui/settings_window.py` | 麥克風選擇 UI + QScrollArea + 間距修復 |

## Test plan
- [ ] 啟動 App，進入設定 → 系統設定，確認「🎤 麥克風選擇」下拉選單出現
- [ ] 下拉選單列出所有系統輸入裝置
- [ ] 選擇外接麥克風後儲存，確認錄音使用指定裝置
- [ ] 使用「系統預設」選項，確認回到預設行為
- [ ] 插拔 USB 麥克風，確認列表 2 秒內自動更新
- [ ] 🔄 按鈕可手動重新偵測裝置
- [ ] 麥克風測試診斷使用選定的裝置
- [ ] 波紋圖形在外接麥克風下有明顯跳動
- [ ] 快捷鍵三行不再重疊
- [ ] 診斷按鈕文字完整顯示

🤖 Generated with [Claude Code](https://claude.com/claude-code)