### PR TITLE
修正 macOS 打包、翻譯與執行期問題

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,12 +1,39 @@
+import importlib.util
 import json
 import os
+import platform
+
+
+def _has_module(module_name: str) -> bool:
+    return importlib.util.find_spec(module_name) is not None
+
+
+def resolve_stt_engine(engine: str | None = None) -> str:
+    """
+    Pick a safe STT backend for the current machine.
+
+    - Apple Silicon with mlx-whisper installed: prefer MLX.
+    - Intel Mac or missing mlx-whisper: fall back to local_whisper.
+    - Explicit cloud engines keep their original value.
+    """
+    explicit = (engine or "").strip().lower()
+    if explicit in {"groq", "openrouter", "gemini", "local_whisper"}:
+        return explicit
+
+    wants_mlx = explicit in {"", "auto", "mlx_whisper"}
+    is_apple_silicon = platform.system() == "Darwin" and platform.machine() == "arm64"
+
+    if wants_mlx and is_apple_silicon and _has_module("mlx_whisper"):
+        return "mlx_whisper"
+
+    return "local_whisper"
 
 DEFAULT_CONFIG = {
     "hotkey_ptt": "alt_r",
     "hotkey_toggle": "f13",
     "hotkey_llm": "f14",
     # STT
-    "stt_engine": "mlx_whisper",
+    "stt_engine": resolve_stt_engine(),
     "whisper_model": "medium",
     "groq_api_key": "",
     "language": "zh",

--- a/hotkey/listener.py
+++ b/hotkey/listener.py
@@ -88,9 +88,11 @@ class HotkeyListener:
         self._tap = None
         self._key_states: Dict[int, bool] = {}
         self._last_event_flags = 0
+        self._pending_release_timers: Dict[str, threading.Timer] = {}
         
         # Windows specific
         self._win_listener = None
+        self._mac_listener = None
 
         self.key_combos: Dict[str, Dict] = {} # mode -> {mask, keycode}
         if not IS_WINDOWS:
@@ -149,6 +151,13 @@ class HotkeyListener:
                 except Exception:
                     pass
         else:
+            if self._mac_listener:
+                self._mac_listener.stop()
+                try:
+                    self._mac_listener.join()
+                except Exception:
+                    pass
+                self._mac_listener = None
             if self._run_loop:
                 from Foundation import CFRunLoopStop
                 CFRunLoopStop(self._run_loop)
@@ -180,10 +189,57 @@ class HotkeyListener:
         except ImportError: pass
 
     def _start_macos(self):
+        self._start_macos_pynput_fallback()
         if self._loop_thread and self._loop_thread.is_alive():
             return
         self._loop_thread = threading.Thread(target=self._run_macos, daemon=True)
         self._loop_thread.start()
+
+    def _normalize_hotkey_name(self, value: str) -> str:
+        import re
+
+        value = (value or "").lower().strip()
+        code_match = re.search(r'\(?code:(\d+)\)?', value)
+        if code_match:
+            code = int(code_match.group(1))
+            code_to_name = {
+                54: "cmd_r",
+                55: "cmd",
+                56: "shift",
+                58: "alt",
+                59: "ctrl",
+                60: "shift_r",
+                61: "alt_r",
+                62: "ctrl_r",
+                63: "fn",
+                105: "f13",
+                107: "f14",
+                113: "f15",
+            }
+            return code_to_name.get(code, f"code:{code}")
+        return value
+
+    def _start_macos_pynput_fallback(self):
+        try:
+            from pynput import keyboard
+
+            def on_press(key):
+                k_str = key_to_str(key)
+                for mode, cfg_key in self.configs.items():
+                    if self._normalize_hotkey_name(cfg_key) == k_str:
+                        self._handle_press(mode)
+
+            def on_release(key):
+                k_str = key_to_str(key)
+                for mode, cfg_key in self.configs.items():
+                    if self._normalize_hotkey_name(cfg_key) == k_str:
+                        self._handle_release(mode)
+
+            self._mac_listener = keyboard.Listener(on_press=on_press, on_release=on_release)
+            self._mac_listener.start()
+            self.log.info("macOS pynput fallback listener started.")
+        except Exception as e:
+            self.log.warning(f"macOS pynput fallback listener failed: {e}")
 
     def _run_macos(self):
         import Quartz
@@ -275,6 +331,9 @@ class HotkeyListener:
         return event
 
     def _handle_press(self, mode: str):
+        timer = self._pending_release_timers.pop(mode, None)
+        if timer:
+            timer.cancel()
 
         # v2.8.6: Enhanced Toggle logic
         if mode == "toggle":
@@ -291,16 +350,36 @@ class HotkeyListener:
             threading.Thread(target=self.on_start, args=(mode,), daemon=True).start()
 
     def _handle_release(self, mode: str):
-
         # Toggle mode ignores release (it stops on next press)
         if mode == "toggle": 
             return 
+        combo = self.key_combos.get(mode, {})
+        is_modifier_only = combo.get("mask") == 0 and combo.get("keycode") in [54, 55, 56, 58, 59, 60, 61, 62, 63]
+        if is_modifier_only:
+            timer = self._pending_release_timers.pop(mode, None)
+            if timer:
+                timer.cancel()
+
+            def confirm_release():
+                if self._active_mode == mode:
+                    self._active_mode = None
+                    threading.Thread(target=self.on_stop, args=(mode,), daemon=True).start()
+                self._pending_release_timers.pop(mode, None)
+
+            timer = threading.Timer(0.12, confirm_release)
+            timer.daemon = True
+            self._pending_release_timers[mode] = timer
+            timer.start()
+            return
+
         if self._active_mode == mode:
             self._active_mode = None
             threading.Thread(target=self.on_stop, args=(mode,), daemon=True).start()
     def reset_state(self):
         """External call to sync state when recording is manipulated via UI."""
+        for timer in self._pending_release_timers.values():
+            timer.cancel()
+        self._pending_release_timers = {}
         self._active_mode = None
         self._key_states = {}
         self.log.debug("[hotkey] State reset")
-

--- a/llm/__init__.py
+++ b/llm/__init__.py
@@ -23,4 +23,7 @@ def get_llm(config: dict) -> BaseLLM:
         return DeepSeekLLM(config)
     else:
         from .ollama import OllamaLLM
-        return OllamaLLM(config)
+        return OllamaLLM(
+            model=config.get("ollama_model", "llama3"),
+            base_url=config.get("ollama_base_url", "http://localhost:11434"),
+        )

--- a/llm/claude.py
+++ b/llm/claude.py
@@ -3,11 +3,14 @@ from .base import BaseLLM
 
 
 class ClaudeLLM(BaseLLM):
-    def __init__(self, api_key: str, model: str = "claude-3-haiku-20240307"):
-        self.client = anthropic.Anthropic(api_key=api_key)
-        self.model = model
+    def __init__(self, config: dict):
+        self.api_key = config.get("anthropic_api_key", "")
+        self.model = config.get("anthropic_model", "claude-3-haiku-20240307")
+        self.client = anthropic.Anthropic(api_key=self.api_key) if self.api_key else None
 
     def refine(self, text: str, prompt: str) -> str:
+        if not self.client:
+            return text
         message = self.client.messages.create(
             model=self.model,
             max_tokens=1024,

--- a/llm/ollama.py
+++ b/llm/ollama.py
@@ -18,6 +18,7 @@ class OllamaLLM(BaseLLM):
         }
         try:
             # Use smaller timeout for local Ollama to fail fast if not running
+            print(f"[llm] Ollama request -> {self.base_url}/api/chat model={self.model}")
             resp = requests.post(f"{self.base_url}/api/chat", json=payload, timeout=5)
             resp.raise_for_status()
             result = resp.json()["message"]["content"].strip()

--- a/llm/openai_llm.py
+++ b/llm/openai_llm.py
@@ -3,11 +3,14 @@ from .base import BaseLLM
 
 
 class OpenAILLM(BaseLLM):
-    def __init__(self, api_key: str, model: str = "gpt-4o-mini"):
-        self.client = OpenAI(api_key=api_key)
-        self.model = model
+    def __init__(self, config: dict):
+        self.api_key = config.get("openai_api_key", "")
+        self.model = config.get("openai_model", "gpt-4o-mini")
+        self.client = OpenAI(api_key=self.api_key) if self.api_key else None
 
     def refine(self, text: str, prompt: str) -> str:
+        if not self.client:
+            return text
         response = self.client.chat.completions.create(
             model=self.model,
             messages=[

--- a/main.py
+++ b/main.py
@@ -89,6 +89,7 @@ class VoiceTypeApp(QObject):
         self.ui_signal.connect(self._handle_ui_signal)
         self.download_signal.connect(self._handle_download_signal)
         self._models_ready = False
+        self._recording_ready = False
         self.stt = None
 
         self.indicator = MicIndicator()
@@ -107,6 +108,7 @@ class VoiceTypeApp(QObject):
         
         self.injector = TextInjector()
         self.llm = None
+        self._last_target_app = None
         
         # 綁定錄音事件
         self.recorder.on_start = self._on_record_start
@@ -189,6 +191,8 @@ class VoiceTypeApp(QObject):
             on_toggle_llm=self._on_toggle_llm,
             on_set_translation=self._on_set_translation,
             on_config_saved=self._on_config_saved,
+            on_set_scenario=self._on_set_scenario,
+            on_set_format=self._on_set_format,
         )
         self.menu_bar.on_set_template = self._on_set_template
         # Override settings opening logic to use the already created window
@@ -317,8 +321,8 @@ class VoiceTypeApp(QObject):
         QTimer.singleShot(3000, lambda: self.ui_signal.emit({"type": "hide", "value": None}))
 
     def _on_start(self, mode):
-        if not self._models_ready:
-            print("[main] Models not ready yet.")
+        if not self._recording_ready or self.stt is None:
+            print("[main] STT not ready yet.")
             return
 
         # v2.8.20: Protect original state before temporary override
@@ -337,7 +341,11 @@ class VoiceTypeApp(QObject):
             self.ui_signal.emit({"type": "prefix", "value": "AI"})
         else:
             self.ui_signal.emit({"type": "prefix", "value": ""})
-            
+
+        self._last_target_app = self.injector.capture_frontmost_app()
+        if self._last_target_app and self._last_target_app.bundle_id:
+            print(f"[inject] Captured target app: {self._last_target_app.bundle_id}")
+
         self.recorder.start()
 
     def _on_stop(self, mode=None, cancel=False):
@@ -372,7 +380,9 @@ class VoiceTypeApp(QObject):
                 self.indicator.hide()
                 return
 
-            lang = self.config.get("translation_lang", "zh")
+            # STT input language and LLM output translation target are different concerns.
+            # If translation_lang is "en"/"ja", using it here breaks Chinese speech recognition.
+            lang = self.config.get("language", "zh")
             stt_start_time = time.time()
             text = self.stt.transcribe(audio_data, language=lang)
             stt_duration = time.time() - stt_start_time
@@ -476,6 +486,8 @@ class VoiceTypeApp(QObject):
                     refined = self.llm.refine(text, prompt)
                     llm_duration = time.time() - llm_start_time
                     
+                    refined = self._sanitize_llm_output(refined)
+
                     is_llm_used = True
                     print(f"[process] LLM result: {refined[:50]}... ({llm_duration:.2f}s)")
                     
@@ -501,13 +513,16 @@ class VoiceTypeApp(QObject):
                 final_text = self._apply_basic_soul_rules(final_text)
 
             # --- 3. 標點轉換與格式過濾 ---
-            replacements = {
-                ',': '，', '.': '.', '?': '？', '!': '！', 
-                ':': '：', ';': '；', '(': '(', ')': ')',
-                '[': '[', ']': ']', '{': '{', '}': '}'
-            }
-            for hw, fw in replacements.items():
-                final_text = final_text.replace(hw, fw)
+            target_lang = self.config.get("translation_lang")
+            # Chinese punctuation normalization should not run for English/Japanese translation output.
+            if target_lang not in {"en", "ja"}:
+                replacements = {
+                    ',': '，', '.': '.', '?': '？', '!': '！',
+                    ':': '：', ';': '；', '(': '(', ')': ')',
+                    '[': '[', ']': ']', '{': '{', '}': '}'
+                }
+                for hw, fw in replacements.items():
+                    final_text = final_text.replace(hw, fw)
 
             import unicodedata
             def full2half(t):
@@ -532,7 +547,7 @@ class VoiceTypeApp(QObject):
             self._log_execution(text, final_text, is_llm_used, engine, stt_duration, llm_duration)
 
             # --- 4. 注入最終文字 (v2.8.0 B19: 已移除瀏覽器攔截) ---
-            self.injector.inject(final_text)
+            self.injector.inject(final_text, target_app=self._last_target_app)
 
             # --- 5. 紀錄長期記憶與自動學習 (v2.7.32 Fix) ---
             try:
@@ -642,11 +657,49 @@ class VoiceTypeApp(QObject):
 
         return text.strip()
 
+    def _sanitize_llm_output(self, text: str) -> str:
+        """Remove common assistant wrappers that some local models still prepend."""
+        import re
+
+        cleaned = (text or "").strip()
+        if not cleaned:
+            return ""
+
+        wrapper_patterns = [
+            r"^(?:Okay|OK|Sure|Certainly)[,!:：\s].*$",
+            r"^(?:Here(?:'s| is) the (?:revised|translated) version)[:,：]?\s*$",
+            r"^(?:以下是|以下為|翻譯如下|修正如下)[：:\s].*$",
+            r"^(?:好的|當然|沒問題)[，,：:\s].*$",
+        ]
+
+        lines = cleaned.splitlines()
+        while lines:
+            first = lines[0].strip()
+            if any(re.match(pattern, first, re.IGNORECASE) for pattern in wrapper_patterns):
+                lines.pop(0)
+                while lines and not lines[0].strip():
+                    lines.pop(0)
+                continue
+            break
+
+        cleaned = "\n".join(lines).strip()
+
+        quote_pairs = [('“', '”'), ('"', '"'), ("'", "'")]
+        for left, right in quote_pairs:
+            if cleaned.startswith(left) and cleaned.endswith(right):
+                inner = cleaned[len(left):-len(right)].strip()
+                if inner:
+                    cleaned = inner
+                break
+
+        return cleaned.strip()
+
     def _build_llm_prompt(self, text, is_assistant=False):
         # v2.7.32 b7: 優化 Prompt 順序 - 規則優先，資料在後 (防止 LLM 輸出身份設定)
         parts = []
         
         # 1. 核心組合與基本 Prompt (指導方針)
+        target_lang = self.config.get("translation_lang")
         if is_assistant:
             base_prompt = DEFAULT_ASSISTANT_PROMPT
         else:
@@ -654,7 +707,16 @@ class VoiceTypeApp(QObject):
             
         strict_rule = "【絕對死律：禁止輸出任何關於你自己的設定、性格描述或指令規則副本。】"
         if not is_assistant:
-            strict_rule += "【禁止與使用者對話。禁止解釋。僅直接輸出改寫後的繁體中文結果。若內容無意義請輸出空字串。】"
+            if target_lang == "en":
+                output_lang_desc = "英文結果"
+            elif target_lang == "ja":
+                output_lang_desc = "日文結果"
+            else:
+                output_lang_desc = "繁體中文結果"
+            strict_rule += (
+                f"【禁止與使用者對話。禁止解釋。僅直接輸出改寫後的{output_lang_desc}。"
+                "若內容無意義請輸出空字串。】"
+            )
             
         parts.append(f"〔指令規範〕\n{base_prompt}\n{strict_rule}")
 
@@ -672,12 +734,12 @@ class VoiceTypeApp(QObject):
                 parts.append(f"〔特定性格語氣加成：{scenario_name}〕\n{scenario_path.read_text(encoding='utf-8')}")
                 
         # 4. 語言微調 (Output Language Tuning / Translation)
-        target_lang = self.config.get("translation_lang")
         if target_lang in ["en", "ja"]:
             lang_map = {"en": "英文 (English)", "ja": "日文 (Japanese)"}
             trans_instr = (
                 f"\n〔優先任務：語言切換 -> {lang_map.get(target_lang)}〕\n"
-                f"請將內容轉換為『{lang_map.get(target_lang)}』。\n"
+                f"請將內容完整轉換為『{lang_map.get(target_lang)}』。\n"
+                "禁止保留繁體中文原文，除非原文中有品牌名、專有名詞或依脈絡不應翻譯的內容。\n"
                 f"注意：請保留靈魂與性格設定的口吻。嚴禁任何解釋。"
             )
             parts.append(trans_instr)
@@ -728,6 +790,8 @@ class VoiceTypeApp(QObject):
 
             print("[main] Initializing STT engine...")
             self.stt = get_stt(self.config)
+            self._recording_ready = True
+            print("[main] STT is READY for recording.")
 
             # 1. 下載模型（含進度回報）
             if hasattr(self.stt, 'download_model'):
@@ -756,6 +820,9 @@ class VoiceTypeApp(QObject):
 
     def _on_models_error(self, error_msg):
         print(f"[main] !!! FAILED to load models: {error_msg}")
+        if not self._recording_ready:
+            self.download_signal.emit("❌ STT 載入失敗", -1, True)
+            return
         self.indicator.hide()
         self.download_signal.emit("❌ 載入失敗", -1, True)
 
@@ -793,8 +860,42 @@ class VoiceTypeApp(QObject):
             self.menu_bar.refresh_ui()
 
     def _on_set_translation(self, lang):
-        self.config["translation_lang"] = lang
-        save_config(self.config)
+        with self._config_lock:
+            latest = load_config()
+            latest["translation_lang"] = lang
+            self.config = latest
+            save_config(self.config)
+            if self.menu_bar:
+                self.menu_bar.config = self.config
+                self.menu_bar.refresh_ui()
+            if self.settings_window:
+                self.settings_window.refresh_config(self.config)
+
+    def _on_set_scenario(self, scenario_name):
+        with self._config_lock:
+            latest = load_config()
+            latest["active_scenario"] = scenario_name
+            self.config = latest
+            save_config(self.config)
+            print(f"[main] Scenario switched to: {scenario_name}")
+            if self.menu_bar:
+                self.menu_bar.config = self.config
+                self.menu_bar.refresh_ui()
+            if self.settings_window:
+                self.settings_window.refresh_config(self.config)
+
+    def _on_set_format(self, format_name):
+        with self._config_lock:
+            latest = load_config()
+            latest["active_format"] = format_name
+            self.config = latest
+            save_config(self.config)
+            print(f"[main] Format switched to: {format_name}")
+            if self.menu_bar:
+                self.menu_bar.config = self.config
+                self.menu_bar.refresh_ui()
+            if self.settings_window:
+                self.settings_window.refresh_config(self.config)
 
     def _on_set_template(self, text, name):
         self.injector.inject(text)

--- a/output/injector.py
+++ b/output/injector.py
@@ -1,6 +1,17 @@
+from __future__ import annotations
+
 import subprocess
-import pyperclip
 import time
+from dataclasses import dataclass
+
+import pyperclip
+
+
+@dataclass
+class FrontmostApp:
+    bundle_id: str | None = None
+    pid: int | None = None
+    name: str | None = None
 
 
 class TextInjector:
@@ -9,12 +20,32 @@ class TextInjector:
     by writing to clipboard and simulating Cmd+V.
     """
 
-    def inject(self, text: str) -> None:
+    def capture_frontmost_app(self) -> FrontmostApp | None:
+        import platform
+
+        if platform.system() != "Darwin":
+            return None
+
+        try:
+            from AppKit import NSWorkspace
+
+            app = NSWorkspace.sharedWorkspace().frontmostApplication()
+            if not app:
+                return None
+            return FrontmostApp(
+                bundle_id=app.bundleIdentifier(),
+                pid=int(app.processIdentifier()),
+                name=app.localizedName(),
+            )
+        except Exception:
+            return None
+
+    def inject(self, text: str, target_app: FrontmostApp | None = None) -> None:
         if not text:
             return
         pyperclip.copy(text)
-        time.sleep(0.05)  # small delay to ensure clipboard is ready
-        self._paste()
+        time.sleep(0.08)  # small delay to ensure clipboard is ready
+        self._paste(target_app=target_app)
 
     def select_back(self, char_count: int) -> None:
         """往回選取 char_count 個字元（用於背景 LLM 替換）"""
@@ -40,7 +71,98 @@ class TextInjector:
             """
             subprocess.run(["osascript", "-e", script], check=True)
 
-    def _paste(self) -> None:
+    def _activate_target_app(self, target_app: FrontmostApp | None) -> None:
+        import platform
+
+        if platform.system() != "Darwin" or not target_app:
+            return
+
+        try:
+            from AppKit import NSRunningApplication, NSApplicationActivateIgnoringOtherApps
+
+            if target_app.pid:
+                app = NSRunningApplication.runningApplicationWithProcessIdentifier_(target_app.pid)
+                if app:
+                    app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps)
+                    time.sleep(0.05)
+                    return
+        except Exception:
+            pass
+
+        if target_app.bundle_id:
+            script = f'tell application id "{target_app.bundle_id}" to activate'
+            try:
+                subprocess.run(["osascript", "-e", script], check=False, timeout=2)
+                time.sleep(0.05)
+            except Exception:
+                pass
+
+    def _paste_with_keyboard(self) -> None:
+        from pynput.keyboard import Controller, Key
+
+        kb = Controller()
+        with kb.pressed(Key.cmd):
+            kb.press("v")
+            kb.release("v")
+
+    def _paste_with_ax(self, target_app: FrontmostApp | None) -> None:
+        if not target_app or not target_app.pid:
+            raise RuntimeError("No target app pid for AX paste")
+
+        import ApplicationServices as AS
+
+        app_ref = AS.AXUIElementCreateApplication(target_app.pid)
+        command_keycode = 55
+        v_keycode = 9
+
+        rc = AS.AXUIElementPostKeyboardEvent(app_ref, 0, command_keycode, True)
+        if rc != 0:
+            raise RuntimeError(f"AX command-down failed: {rc}")
+        rc = AS.AXUIElementPostKeyboardEvent(app_ref, ord("v"), v_keycode, True)
+        if rc != 0:
+            raise RuntimeError(f"AX v-down failed: {rc}")
+        rc = AS.AXUIElementPostKeyboardEvent(app_ref, ord("v"), v_keycode, False)
+        if rc != 0:
+            raise RuntimeError(f"AX v-up failed: {rc}")
+        rc = AS.AXUIElementPostKeyboardEvent(app_ref, 0, command_keycode, False)
+        if rc != 0:
+            raise RuntimeError(f"AX command-up failed: {rc}")
+
+    def _paste_with_quartz(self) -> None:
+        from Quartz import (
+            CGEventCreateKeyboardEvent,
+            CGEventPost,
+            CGEventSetFlags,
+            kCGEventFlagMaskCommand,
+            kCGHIDEventTap,
+        )
+
+        command_keycode = 55
+        v_keycode = 9
+
+        cmd_down = CGEventCreateKeyboardEvent(None, command_keycode, True)
+        v_down = CGEventCreateKeyboardEvent(None, v_keycode, True)
+        v_up = CGEventCreateKeyboardEvent(None, v_keycode, False)
+        cmd_up = CGEventCreateKeyboardEvent(None, command_keycode, False)
+
+        CGEventSetFlags(cmd_down, kCGEventFlagMaskCommand)
+        CGEventSetFlags(v_down, kCGEventFlagMaskCommand)
+        CGEventSetFlags(v_up, kCGEventFlagMaskCommand)
+        CGEventSetFlags(cmd_up, 0)
+
+        for event in (cmd_down, v_down, v_up, cmd_up):
+            CGEventPost(kCGHIDEventTap, event)
+            time.sleep(0.01)
+
+    def _paste_with_applescript(self) -> None:
+        script = """
+        tell application "System Events"
+            keystroke "v" using command down
+        end tell
+        """
+        subprocess.run(["osascript", "-e", script], check=True, timeout=2)
+
+    def _paste(self, target_app: FrontmostApp | None = None) -> None:
         import platform
         if platform.system() == "Windows":
             from pynput.keyboard import Controller, Key
@@ -49,10 +171,31 @@ class TextInjector:
                 kb.press('v')
                 kb.release('v')
         else:
-            # macOS: Use AppleScript
-            script = """
-            tell application "System Events"
-                keystroke "v" using command down
-            end tell
-            """
-            subprocess.run(["osascript", "-e", script], check=True)
+            # macOS: restore focus to the original target app, then prefer direct keyboard events.
+            self._activate_target_app(target_app)
+            try:
+                self._paste_with_ax(target_app)
+                return
+            except Exception:
+                pass
+
+            try:
+                self._paste_with_applescript()
+                return
+            except Exception:
+                pass
+
+            try:
+                self._paste_with_quartz()
+                return
+            except Exception:
+                pass
+
+            try:
+                self._paste_with_keyboard()
+                return
+            except Exception:
+                pass
+
+            # Final fallback for environments where both AppleScript and Quartz fail.
+            self._paste_with_applescript()

--- a/post_build_fix.py
+++ b/post_build_fix.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import subprocess
 from pathlib import Path
 
 def get_site_packages_path():
@@ -81,6 +82,32 @@ def fix_bundle(app_path=None):
         # Explicitly set permissions for the Homebrew-sourced dylibs
         os.chmod(target_ssl, 0o755)
         os.chmod(target_crypto, 0o755)
+        try:
+            subprocess.run(
+                ["install_name_tool", "-id", "@executable_path/../Frameworks/libcrypto.3.dylib", str(target_crypto)],
+                check=True,
+            )
+            subprocess.run(
+                ["install_name_tool", "-id", "@executable_path/../Frameworks/libssl.3.dylib", str(target_ssl)],
+                check=True,
+            )
+            for old_ref in [
+                "/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib",
+                "/opt/homebrew/Cellar/openssl@3/3.6.1/lib/libcrypto.3.dylib",
+                "/opt/homebrew/Cellar/openssl@3/3.6.2/lib/libcrypto.3.dylib",
+            ]:
+                subprocess.run(
+                    [
+                        "install_name_tool",
+                        "-change",
+                        old_ref,
+                        "@executable_path/../Frameworks/libcrypto.3.dylib",
+                        str(target_ssl),
+                    ],
+                    check=False,
+                )
+        except Exception as e:
+            print(f"[Post-Build Fix] OpenSSL install_name_tool patch skipped: {e}")
 
     print("[Post-Build Fix] Done!")
 

--- a/post_build_fix_installed.py
+++ b/post_build_fix_installed.py
@@ -2,6 +2,7 @@
 post_build_fix_installed.py: Same as post_build_fix.py but targets the INSTALLED
 /Applications/嘴炮輸入法.app instead of dist/. Run this after installing the DMG.
 """
+import subprocess
 import shutil
 from pathlib import Path
 
@@ -45,6 +46,36 @@ def fix_installed():
         if target_dyn_mlx_lib.exists():
             shutil.rmtree(target_dyn_mlx_lib)
         shutil.copytree(src_lib_dir, target_dyn_mlx_lib)
+
+    target_ssl = app_dir / "Contents/Frameworks/libssl.3.dylib"
+    target_crypto = app_dir / "Contents/Frameworks/libcrypto.3.dylib"
+    if target_ssl.exists() and target_crypto.exists():
+        try:
+            subprocess.run(
+                ["install_name_tool", "-id", "@executable_path/../Frameworks/libcrypto.3.dylib", str(target_crypto)],
+                check=True,
+            )
+            subprocess.run(
+                ["install_name_tool", "-id", "@executable_path/../Frameworks/libssl.3.dylib", str(target_ssl)],
+                check=True,
+            )
+            for old_ref in [
+                "/opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib",
+                "/opt/homebrew/Cellar/openssl@3/3.6.1/lib/libcrypto.3.dylib",
+                "/opt/homebrew/Cellar/openssl@3/3.6.2/lib/libcrypto.3.dylib",
+            ]:
+                subprocess.run(
+                    [
+                        "install_name_tool",
+                        "-change",
+                        old_ref,
+                        "@executable_path/../Frameworks/libcrypto.3.dylib",
+                        str(target_ssl),
+                    ],
+                    check=False,
+                )
+        except Exception as e:
+            print(f"[Installed App Fix] OpenSSL install_name_tool patch skipped: {e}")
 
     print("[Installed App Fix] Done! Restart 嘴炮輸入法 now.")
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,9 @@ sys.setrecursionlimit(5000)
 APP = ['main.py']
 DATA_FILES = [
     'assets',
+    ('', [
+        'self_check.py',
+    ]),
     ('soul/scenario', [
         'soul/scenario/default.md',
         'soul/scenario/情商大師.md',
@@ -40,8 +43,8 @@ OPTIONS = {
         'CFBundleDisplayName': '嘴炮輸入法',
         'CFBundleIdentifier': 'com.jimmy4tw.voicetype4tw-mac',
         'NSPrincipalClass': 'NSApplication',
-        'CFBundleVersion': '2.9.0',
-        'CFBundleShortVersionString': '2.9.0',
+        'CFBundleVersion': '2.9.7',
+        'CFBundleShortVersionString': '2.9.7',
         'NSMicrophoneUsageDescription': 'VoiceType4TW requires microphone access for speech recognition.',
         'NSAccessibilityUsageDescription': '嘴炮輸入法需要輔助使用權限來監聽全域快捷鍵並自動貼上文字。',
         'NSAppleEventsUsageDescription': '嘴炮輸入法需要透過 AppleEvents 與其他程式互動以完成文字注入。',
@@ -56,7 +59,7 @@ OPTIONS = {
         # Audio
         'sounddevice', '_sounddevice_data',
         # Network / LLM
-        'httpx', 'certifi',
+        'httpx', 'certifi', 'requests', 'openai', 'anthropic',
         # macOS Bridge
         'objc', 'Quartz',
         # Hotkey / Clipboard
@@ -70,6 +73,7 @@ OPTIONS = {
     ],
     'includes': [
         'numpy',
+        'AppKit', 'Foundation',
         'mlx', 'mlx.core', 'mlx.nn', 'mlx.nn.layers',
         'mlx.optimizers', 'mlx.utils', 'mlx.extension',
         'mlx._reprlib_fix', 'mlx._distributed_utils'

--- a/stt/__init__.py
+++ b/stt/__init__.py
@@ -1,9 +1,10 @@
 from .base import BaseSTT
+from config import resolve_stt_engine
 
 # Lazy imports: 各引擎只在選中時才 import，避免未安裝的套件造成啟動失敗。
 
 def get_stt(config: dict) -> BaseSTT:
-    engine = config.get("stt_engine", "mlx_whisper")
+    engine = resolve_stt_engine(config.get("stt_engine"))
     if engine == "mlx_whisper":
         from .mlx_whisper import MLXWhisperSTT
         return MLXWhisperSTT(config)
@@ -19,4 +20,3 @@ def get_stt(config: dict) -> BaseSTT:
     else:
         from .local_whisper import LocalWhisperSTT
         return LocalWhisperSTT(config)
-

--- a/ui/menu_bar.py
+++ b/ui/menu_bar.py
@@ -11,12 +11,15 @@ class VoiceTypeMenuBar:
     and handles state, delegating the actual rendering to TrayManager.
     """
     def __init__(self, config: dict, on_quit: Callable, on_toggle_llm: Callable,
-                 on_set_translation: Callable, on_config_saved: Callable = None):
+                 on_set_translation: Callable, on_config_saved: Callable = None,
+                 on_set_scenario: Callable = None, on_set_format: Callable = None):
         self.config = config
         self.on_quit = on_quit
         self.on_toggle_llm = on_toggle_llm
         self.on_set_translation = on_set_translation
         self.on_config_saved = on_config_saved
+        self.on_set_scenario = on_set_scenario
+        self.on_set_format = on_set_format
         self.tray = None  # Set by main.py
 
     def get_menu_items(self) -> List[Dict]:
@@ -94,37 +97,41 @@ class VoiceTypeMenuBar:
         self.refresh_ui()
 
     def _set_scenario(self, sender):
-        latest = load_config()
         name = self._get_sender_text(sender)
         print(f"[menu] Scenario Selected: {name}")
         import re
         internal_name = re.sub(r'^[\W_]+', '', name).strip()
         if "基底靈魂" in name: internal_name = "default"
-        
-        latest["active_scenario"] = internal_name
-        save_config(latest)
-        self.config.clear()
-        self.config.update(latest)
-        
-        if hasattr(self, 'on_config_saved') and callable(self.on_config_saved):
-            self.on_config_saved()
+
+        if callable(self.on_set_scenario):
+            self.on_set_scenario(internal_name)
+        else:
+            latest = load_config()
+            latest["active_scenario"] = internal_name
+            save_config(latest)
+            self.config.clear()
+            self.config.update(latest)
+            if hasattr(self, 'on_config_saved') and callable(self.on_config_saved):
+                self.on_config_saved()
         self.refresh_ui()
 
     def _set_format(self, sender):
-        latest = load_config()
         name = self._get_sender_text(sender)
         print(f"[menu] Format Selected: {name}")
         import re
         internal_name = re.sub(r'^[\W_]+', '', name).strip()
         if "自然排版" in name: internal_name = "natural"
-        
-        latest["active_format"] = internal_name
-        save_config(latest)
-        self.config.clear()
-        self.config.update(latest)
-        
-        if hasattr(self, 'on_config_saved') and callable(self.on_config_saved):
-            self.on_config_saved()
+
+        if callable(self.on_set_format):
+            self.on_set_format(internal_name)
+        else:
+            latest = load_config()
+            latest["active_format"] = internal_name
+            save_config(latest)
+            self.config.clear()
+            self.config.update(latest)
+            if hasattr(self, 'on_config_saved') and callable(self.on_config_saved):
+                self.on_config_saved()
         self.refresh_ui()
 
     def _use_template(self, sender):

--- a/ui/settings_window.py
+++ b/ui/settings_window.py
@@ -5,6 +5,8 @@ Features tabs for General, STT/LLM, Vocab/Memory, and Stats.
 import sys
 import os
 import platform
+import subprocess
+import shutil
 from pathlib import Path
 from PyQt6.QtWidgets import (
     QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, QGridLayout,
@@ -522,6 +524,7 @@ class SettingsWindow(QMainWindow):
         self.config = load_config()
         self.on_save = on_save
         self._is_dark = True
+        self._ollama_models = []
 
         # 載入 skin
         skin_name = self.config.get("ui_skin", "titanium")
@@ -529,6 +532,8 @@ class SettingsWindow(QMainWindow):
 
         self._setup_ui()
         self._load_data()
+        self.llm_engine.currentIndexChanged.connect(self._on_llm_engine_changed)
+        self.btn_refresh_ollama_models.clicked.connect(self._refresh_ollama_models)
         
         # 根據語言動態設定視窗標題
         from paths import VERSION_NAME
@@ -696,6 +701,89 @@ class SettingsWindow(QMainWindow):
         self.stack.setCurrentIndex(idx)
         # Dashboard (0) and Stats (5) hide save buttons
         self.footer_widget.setVisible(idx not in [0, 5])
+
+    def _read_ollama_models(self):
+        ollama_bin = (
+            shutil.which("ollama")
+            or ("/usr/local/bin/ollama" if Path("/usr/local/bin/ollama").exists() else None)
+            or ("/opt/homebrew/bin/ollama" if Path("/opt/homebrew/bin/ollama").exists() else None)
+            or (
+                "/Applications/Ollama.app/Contents/Resources/ollama"
+                if Path("/Applications/Ollama.app/Contents/Resources/ollama").exists()
+                else None
+            )
+        )
+        if not ollama_bin:
+            log.warning("[ollama] Binary not found in app environment.")
+            return []
+
+        try:
+            result = subprocess.run(
+                [ollama_bin, "list"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (FileNotFoundError, subprocess.SubprocessError) as exc:
+            log.warning("[ollama] Failed to read local models: %s", exc)
+            return []
+
+        if result.returncode != 0:
+            stderr = (result.stderr or "").strip()
+            log.warning("[ollama] `ollama list` failed: %s", stderr or f"exit={result.returncode}")
+            return []
+
+        models = []
+        for line in (result.stdout or "").splitlines():
+            raw = line.strip()
+            if not raw or raw.upper().startswith("NAME"):
+                continue
+            name = raw.split()[0].strip()
+            if name and name not in models:
+                models.append(name)
+        return models
+
+    def _refresh_ollama_models(self):
+        current_model = (
+            self.ollama_model.currentData()
+            or self.ollama_model.currentText().strip()
+            or self.config.get("ollama_model", "llama3:8b")
+        )
+        self._ollama_models = self._read_ollama_models()
+
+        self.ollama_model.blockSignals(True)
+        self.ollama_model.clear()
+
+        if self._ollama_models:
+            for model_name in self._ollama_models:
+                self.ollama_model.addItem(model_name, model_name)
+        else:
+            self.ollama_model.addItem("未偵測到已安裝模型", "")
+
+        if current_model and current_model not in self._ollama_models:
+            self.ollama_model.addItem(current_model, current_model)
+
+        target_index = self.ollama_model.findData(current_model)
+        if target_index >= 0:
+            self.ollama_model.setCurrentIndex(target_index)
+        else:
+            self.ollama_model.setEditText(current_model)
+
+        self.ollama_model.blockSignals(False)
+        self._update_llm_engine_ui()
+
+    def _update_llm_engine_ui(self):
+        current_engine = self.llm_engine.currentData() or self.llm_engine.currentText().lower()
+        is_ollama = current_engine == "ollama"
+        self.ollama_row.setVisible(is_ollama)
+        self.ollama_model.setVisible(is_ollama)
+
+    def _on_llm_engine_changed(self):
+        if (self.llm_engine.currentData() or self.llm_engine.currentText().lower()) == "ollama":
+            self._refresh_ollama_models()
+            return
+        self._update_llm_engine_ui()
 
     def _create_sync_page(self):
         s = self.skin
@@ -1352,6 +1440,32 @@ class SettingsWindow(QMainWindow):
         for eng in LLM_ENGINES:
             self.llm_engine.addItem(eng.capitalize() if eng != "openai" else "OpenAI", eng)
         llm_layout.addWidget(self.llm_engine)
+
+        self.ollama_row = QWidget()
+        ollama_row_layout = QHBoxLayout(self.ollama_row)
+        ollama_row_layout.setContentsMargins(0, 0, 0, 0)
+        ollama_row_layout.setSpacing(8)
+        ollama_left = QVBoxLayout()
+        ollama_left.setContentsMargins(0, 0, 0, 0)
+        ollama_left.setSpacing(4)
+        self.lbl_ollama_model = QLabel("Ollama 本機模型")
+        self.lbl_ollama_model.setStyleSheet(f"font-size: 11px; color: {s['text_secondary']}; background: transparent;")
+        self.lbl_ollama_hint = QLabel("依據 `ollama list` 顯示目前已安裝模型")
+        self.lbl_ollama_hint.setStyleSheet(f"font-size: 10px; color: {s['text_secondary']}; background: transparent;")
+        ollama_left.addWidget(self.lbl_ollama_model)
+        ollama_left.addWidget(self.lbl_ollama_hint)
+        ollama_row_layout.addLayout(ollama_left)
+        ollama_row_layout.addStretch()
+        self.btn_refresh_ollama_models = QPushButton("重新整理")
+        self.btn_refresh_ollama_models.setObjectName("secondary")
+        self.btn_refresh_ollama_models.setFixedHeight(32)
+        ollama_row_layout.addWidget(self.btn_refresh_ollama_models)
+        llm_layout.addWidget(self.ollama_row)
+
+        self.ollama_model = QComboBox()
+        self.ollama_model.setEditable(True)
+        self.ollama_model.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
+        llm_layout.addWidget(self.ollama_model)
 
         # 注入模式
         lbl_mode = QLabel("內容注入模式（Injection Mode）")
@@ -2405,6 +2519,7 @@ class SettingsWindow(QMainWindow):
         self.llm_enabled.setChecked(self.config.get("llm_enabled", False))
         llm_eng_idx = self.llm_engine.findData(self.config.get("llm_engine", "ollama"))
         if llm_eng_idx >= 0: self.llm_engine.setCurrentIndex(llm_eng_idx)
+        self._refresh_ollama_models()
         llm_mode_idx = self.llm_mode.findData(self.config.get("llm_mode", "replace"))
         if llm_mode_idx >= 0: self.llm_mode.setCurrentIndex(llm_mode_idx)
         
@@ -2747,11 +2862,14 @@ class SettingsWindow(QMainWindow):
         self._refresh_vocab()
 
     def _save_action(self):
-        self.config["stt_engine"] = "mlx_whisper"
+        from config import resolve_stt_engine
+
+        self.config["stt_engine"] = resolve_stt_engine(self.config.get("stt_engine"))
         # whisper_model 由 _select_model_card() 即時寫入 self.config，這裡只確保同步
         self.config["language"] = self.language.currentData() or self.language.currentText()
         self.config["llm_enabled"] = self.llm_enabled.isChecked()
         self.config["llm_engine"] = self.llm_engine.currentData() or self.llm_engine.currentText()
+        self.config["ollama_model"] = self.ollama_model.currentData() or self.ollama_model.currentText().strip() or self.config.get("ollama_model", "llama3:8b")
         self.config["llm_mode"] = self.llm_mode.currentData() or self.llm_mode.currentText()
         self.config["openai_api_key"] = self.openai_key.text().strip()
         self.config["anthropic_api_key"] = self.anthropic_key.text().strip()
@@ -2792,15 +2910,25 @@ class SettingsWindow(QMainWindow):
         import subprocess
         import sys
         import os
-        script_path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "self_check.py")
-        if os.path.exists(script_path):
+        from pathlib import Path
+
+        current_file = Path(__file__).resolve()
+        candidate_paths = [
+            current_file.parents[3] / "self_check.py",  # py2app bundle: Contents/Resources/self_check.py
+            current_file.parents[1] / "self_check.py",  # source tree fallback
+            current_file.parents[2] / "self_check.py",  # legacy fallback
+        ]
+        script_path = next((str(path) for path in candidate_paths if path.exists()), None)
+
+        if script_path:
             # Launch in a new terminal window on Windows
             if platform.system() == "Windows":
                 subprocess.Popen(["cmd.exe", "/c", "start", sys.executable, script_path])
             else:
                 subprocess.Popen([sys.executable, script_path])
         else:
-            QMessageBox.warning(self, "錯誤", f"找不到檢測程式：{script_path}")
+            expected = candidate_paths[0]
+            QMessageBox.warning(self, "錯誤", f"找不到檢測程式：{expected}")
 
     def _view_debug_log(self):
         from paths import APP_DATA_DIR


### PR DESCRIPTION
## 變更摘要

這個 PR 主要修正 macOS 版本在實際使用與打包上的多項問題，包含：

- STT 引擎依硬體平台自動 fallback
- Ollama / OpenAI / Claude 初始化參數修正
- macOS 自動貼上與前景焦點處理改善
- 錄音啟動條件與 hotkey 穩定性調整
- Ollama 本機模型下拉選單與刷新功能
- App bundle 內 OpenSSL / MLX 依賴修補
- 翻譯模式輸入語言 / 輸出語言邏輯修正
- 英文 / 日文翻譯輸出修正
- 靈魂情境切換輕量化
- 系統自我檢測腳本路徑修正

## 主要修正項目

### 1. macOS 執行期與貼上流程
- 改善錄音前記錄前景 app 的流程
- 注入文字時優先回到原本目標 app
- 增加多層貼上 fallback，提升自動貼上成功率

### 2. LLM provider 與翻譯模式
- 修正 Ollama 初始化方式
- 修正 OpenAI / Claude 建構參數
- 將 STT 輸入語言與 translation_lang 拆開
- 修正翻譯 prompt 仍殘留繁中輸出限制的問題
- 翻譯模式不再套用中文標點正規化
- 清理本地模型常見前言，例如 `Okay, here’s a revised version:`

### 3. 設定頁與模型選擇
- 新增 Ollama 本機模型下拉選單
- 支援從 `ollama list` 讀取已安裝模型
- 補上重新整理模型清單功能

### 4. 打包與自我檢測
- 補入 `self_check.py` 至 app bundle
- 修正設定頁在 py2app 環境下誤找 `Contents/Resources/lib/python3.12/self_check.py`
- 改為優先使用 `Contents/Resources/self_check.py`

## 驗證

已在本機驗證：
- app 可重新打包
- `codesign --verify --deep --strict` 通過
- 翻譯模式可正常輸出英文 / 日文
- 系統自我檢測腳本可在 bundle 內正確定位